### PR TITLE
Encrypt wallets with a password

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,20 +25,21 @@
   },
   "homepage": "https://github.com/weifund/weifund-dapp-basic#readme",
   "dependencies": {
+    "es6-promisify": "5.0.0",
     "eth-lightwallet": "2.5.3",
     "ipfs-js": "0.0.11",
     "node-polyglot": "2.0.0",
     "qrious": "2.0.2",
     "sheet-router": "4.0.0-0",
     "store": "1.3.20",
-    "xss": "0.2.13",
-    "yo-yo": "1.3.2",
     "web3": "0.15.3",
     "web3-network-detective": "0.1.1",
     "web3-provider-engine": "8.2.0",
     "weifund-contracts": "2.0.3",
     "weifund-lib": "0.1.3",
-    "weifund-util": "git+https://github.com/weifund/weifund-util"
+    "weifund-util": "git+https://github.com/weifund/weifund-util",
+    "xss": "0.2.13",
+    "yo-yo": "1.3.2"
   },
   "devDependencies": {
     "babel-cli": "6.10.1",

--- a/src/components/campaignContributeWallet.js
+++ b/src/components/campaignContributeWallet.js
@@ -81,7 +81,7 @@ function campaignContributeWallet(options) {
 
     </div>
 
-    <div id="view-campaign-contribute-wallet-password" class="row center-block container"
+    <div id="view-campaign-contribute-wallet-seed" class="row center-block container"
       style=" display: none; margin-top: 40px;">
 
       <h2>YOUR LIGHTWALLET</h2>
@@ -132,11 +132,9 @@ function campaignContributeWallet(options) {
       <br />
 
 
-      <a href="/campaign/${campaignObject.id}/contribute/wallet/password">
-        <div style="width: 100%; height: 15px; background: #F1F1F1;">
-          <div class="progress" style="width: 0; height: 15px; background: #ff7518"></div>
-        </div>
-      </a>
+      <div style="width: 100%; height: 15px; background: #F1F1F1;">
+        <div class="progress" style="width: 0; height: 15px; background: #ff7518"></div>
+      </div>
 
       ${campaignContributeNav({
         backURL: `/campaign/${campaignObject.id}/contribute/wallet`,
@@ -160,7 +158,7 @@ function campaignContributeWallet(options) {
 
       <br />
 
-      <a disabled href="/campaign/${campaignObject.id}/contribute/wallet/balance" class="confirm btn btn-primary">
+      <a disabled href="/campaign/${campaignObject.id}/contribute/wallet/password" class="confirm btn btn-primary">
         CONFIRM SEED PHRASE
       </a>
 
@@ -169,6 +167,38 @@ function campaignContributeWallet(options) {
         showNextButton: false,
       })}
     </div>
+
+    <div id="view-campaign-contribute-wallet-password" class="row center-block container"
+      style=" display: none; margin-top: 40px;">
+
+      <h2>YOUR LIGHTWALLET</h2>
+
+      <br />
+      <br />
+
+      <h4>
+        Seed phrases are unencrypted, but WeiFund encrypts your in-app
+        lightwallet with a password that you'll need to enter before the app
+        can access your assets. Choose a password to protect your lightwallet
+        from unauthorized access.
+      </h4>
+
+      <br />
+      <br />
+
+      <form>
+        <input name="password-1" type="password" class="form-control" placeholder="ENTER PASSWORD" />
+        <input name="password-2" type="password" class="form-control" placeholder="REPEAT PASSWORD" />
+        <br />
+        <input type="submit" disabled value="ENCRYPT" class="encrypt btn btn-primary" />
+      </form>
+
+      ${campaignContributeNav({
+        backURL: `/campaign/${campaignObject.id}/contribute/wallet`,
+        showNextButton: false,
+      })}
+    </div>
+
 
     <div id="view-campaign-contribute-wallet-restore" class="row center-block container"
       style=" display: none; margin-top: 40px;">

--- a/src/handlers/handleEncryptSeed.js
+++ b/src/handlers/handleEncryptSeed.js
@@ -1,0 +1,109 @@
+import promisify from 'es6-promisify';
+import lightwallet from 'eth-lightwallet';
+import QRious from 'qrious';
+
+import { viewLoader } from '../components';
+import { el } from '../document';
+import { t } from '../i18n';
+import { createEncryptedKeystore, getSeed, setKeystore, setWalletProvider } from '../keystore';
+import { getRouter } from '../router';
+import { web3 } from '../web3';
+
+/**
+ * Create a function that updates the wallet UI depending on the account's balance.
+ *
+ * Returns a Promise that resolves to whether the user has a non-zero balance.
+ */
+export function contributionBalanceUpdater(address) {
+  function updateContributionBalance() {
+    const getBalance = promisify(web3.eth.getBalance);
+    return getBalance(address)
+      .then(balance => {
+        const balanceEl = el('#view-campaign-contribute-wallet-balance .account-balance');
+        balanceEl.innerHTML = web3.fromWei(balance, 'ether');
+        if (balance.gte(web3.toWei(1, 'ether'))) {
+          const contributeEl = el('#view-campaign-contribute-wallet-balance a.contribute');
+          contributeEl.removeAttribute('disabled');
+          return true;
+        }
+        return false;
+      });
+  }
+
+  return updateContributionBalance;
+}
+
+function startPollingForBalance(address) {
+  // Keep polling until the contribute button is clicked.
+  let keepPolling = true;
+  const contributeEl = el('#view-campaign-contribute-wallet-balance a.contribute');
+  contributeEl.addEventListener('click', () => { keepPolling = false; });
+
+  const updateBalance = contributionBalanceUpdater(address);
+  function pollForBalance() {
+    return updateBalance()
+      .catch(() => false)
+      .then(hasBalance => {
+        if (!hasBalance && keepPolling) {
+          setTimeout(pollForBalance, 10000);
+        }
+      });
+  }
+  return pollForBalance();
+}
+
+export function updateWalletUI() {
+  const getAccounts = promisify(web3.eth.getAccounts);
+  getAccounts()
+    .then(accounts => {
+      const address = `0x${accounts[0]}`;
+      const addressEl = el('#view-campaign-contribute-wallet-balance .user-address');
+      addressEl.innerHTML = address;
+
+      new QRious({
+        element: el('#campaign-contribute-qrcode'),
+        size: 250,
+        value: address,
+      });
+
+      return startPollingForBalance(address);
+    });
+}
+
+export default function handleEncryptSeed(event) {
+  event.preventDefault();
+  // Browsers will noticed the unsubmitted form and warn users about unsaved
+  // changes when they try to navigate away. This disables that check.
+  window.onbeforeunload = null;
+
+  const formEl = el('#view-campaign-contribute-wallet-password form');
+  const password1 = formEl.querySelector('input[name=password-1]');
+  const password2 = formEl.querySelector('input[name=password-2]');
+  if (password1.value !== password2.value) {
+    // If the passwords don't match, abort. The submit button in the UI should
+    // still be disabled.
+    return;
+  }
+  const password = password1.value;
+  formEl.reset();
+
+  // Show loading spinner.
+  const campaignId = parseInt(el('#campaign_id').value);
+  el('#view-campaign-contribute').style.display = 'none';
+  el('#view-focus').style.display = 'block';
+  el('#view-focus').innerHTML = '';
+  el('#view-focus').appendChild(viewLoader({ t }));
+
+  getSeed()
+    .then(seedPhrase => createEncryptedKeystore(seedPhrase, password))
+    .then(keystore => {
+      setKeystore(keystore);
+      setWalletProvider(keystore);
+      return keystore;
+    })
+    .then(updateWalletUI)
+    .then(() => {
+      // Navigate from the loading screen to the account display.
+      getRouter()(`/campaign/${campaignId}/contribute/wallet/balance`);
+    })
+}

--- a/src/handlers/handleEncryptSeed.js
+++ b/src/handlers/handleEncryptSeed.js
@@ -72,7 +72,7 @@ export function updateWalletUI() {
 
 export default function handleEncryptSeed(event) {
   event.preventDefault();
-  // Browsers will noticed the unsubmitted form and warn users about unsaved
+  // Browsers will notice the unsubmitted form and warn users about unsaved
   // changes when they try to navigate away. This disables that check.
   window.onbeforeunload = null;
 

--- a/src/handlers/handleRestoreSeed.js
+++ b/src/handlers/handleRestoreSeed.js
@@ -1,8 +1,5 @@
-import { updateWalletUI } from './handleGenerateWallet';
-import { viewLoader } from '../components';
 import { el } from '../document';
-import { t } from '../i18n';
-import { createUnlockedKeystore, getSeed, setKeystore, setWalletProvider } from '../keystore';
+import { setSeed } from '../keystore';
 import { getRouter } from '../router';
 
 
@@ -10,23 +7,9 @@ export default function handleRestoreSeed(event) {
   event.preventDefault();
 
   const seedEl = el('#view-campaign-contribute-wallet-restore input[type=text]');
-  const seedPhrase = seedEl.value;
+  setSeed(seedEl.value);
+  seedEl.value = '';
   const campaignId = parseInt(el('#campaign_id').value);
-
-  // Show loading spinner.
-  el('#view-campaign-contribute').style.display = 'none';
-  el('#view-focus').style.display = 'block';
-  el('#view-focus').innerHTML = '';
-  el('#view-focus').appendChild(viewLoader({ t }));
-
-  createUnlockedKeystore(seedPhrase)
-    .then(keystore => {
-      setKeystore(keystore);
-      return setWalletProvider(keystore);
-    })
-    .then(updateWalletUI)
-    .then(() => {
-      // Navigate from the loading screen to the account display.
-      getRouter()(`/campaign/${campaignId}/contribute/wallet/balance`);
-    });
+  // Navigate to the encryption screen.
+  getRouter()(`/campaign/${campaignId}/contribute/wallet/password`);
 }

--- a/src/handlers/handleVerifyPassword.js
+++ b/src/handlers/handleVerifyPassword.js
@@ -1,0 +1,12 @@
+import { el } from '../document';
+
+
+export default function handleVerifyPassword(event) {
+  const formEl = el('#view-campaign-contribute-wallet-password form');
+  const password1 = formEl.querySelector('input[name=password-1]');
+  const password2 = formEl.querySelector('input[name=password-2]');
+  if (password1.value === password2.value) {
+    const buttonEl = formEl.querySelector('input[type=submit]');
+    buttonEl.removeAttribute('disabled');
+  }
+}

--- a/src/handlers/handleVerifySeed.js
+++ b/src/handlers/handleVerifySeed.js
@@ -8,6 +8,9 @@ export default function handleVerifySeed(event) {
       if (seed.toLowerCase() == event.target.value.toLowerCase()) {
         const confirmButton = el('#view-campaign-contribute-wallet-confirm a.confirm');
         confirmButton.removeAttribute('disabled');
+        // Remove the seed from the DOM.
+        const seedEl = el('#view-campaign-contribute-wallet-seed .seed');
+        seedEl.innerHTML = '...';
       }
     });
 }

--- a/src/handlers/loadAndDrawCampaignContribute.js
+++ b/src/handlers/loadAndDrawCampaignContribute.js
@@ -28,8 +28,10 @@ const campaignRegistry = contracts.CampaignRegistry.instance();
 // handle cmapaign contribution
 // build all input sliders
 import handleCampaignContribution from './handleCampaignContribution';
+import handleEncryptSeed from './handleEncryptSeed';
 import handleGenerateWallet from './handleGenerateWallet';
 import handleRestoreSeed from './handleRestoreSeed';
+import handleVerifyPassword from './handleVerifyPassword';
 import handleVerifySeed from './handleVerifySeed';
 import buildAllInputSliders from './drawAllInputSliders';
 import handleConfirmOnPageExit from './handleConfirmOnPageExit';
@@ -159,6 +161,9 @@ function loadAndDrawCampaignContribute(campaignID, callback) {
     el('#view-campaign-contribute-wallet a.generate').addEventListener('click', handleGenerateWallet);
     el('#view-campaign-contribute-wallet-restore a.restore').addEventListener('click', handleRestoreSeed);
     el('#view-campaign-contribute-wallet-confirm input[type=text]').addEventListener('keyup', handleVerifySeed);
+    el('#view-campaign-contribute-wallet-password input[name=password-1]').addEventListener('keyup', handleVerifyPassword);
+    el('#view-campaign-contribute-wallet-password input[name=password-2]').addEventListener('keyup', handleVerifyPassword);
+    el('#view-campaign-contribute-wallet-password form').addEventListener('submit', handleEncryptSeed);
 
     /*
 

--- a/src/keystore.js
+++ b/src/keystore.js
@@ -1,3 +1,4 @@
+import promisify from 'es6-promisify';
 import lightwallet from 'eth-lightwallet';
 import Web3 from 'web3';
 import ProviderEngine from 'web3-provider-engine';
@@ -6,68 +7,63 @@ import Web3Subprovider from 'web3-provider-engine/subproviders/web3';
 
 import { web3 } from './web3';
 
-// We disable passwords in eth-lightwallet since we do not store keys on disk.
-// The key is immediately used to fund the campaign, and there's no gain from
-// encrypting the keys from when they're entered to when they're used. Keys
-// remain accessible until the browser window is closed.
-// TODO: Reset the web3 provider after a timeout and after contributions are
-//       made.
-const PASSWORD = 'Disable passwords.';
-const SALT = 'salt';
-// Allow keystore to be unlocked without prompting for a password.
-const passwordProvider = function (cb) { cb(null, password); };
 
-
-export function createUnlockedKeystore(seedPhrase) {
-  return new Promise((resolve, reject) => {
-    lightwallet.keystore.createVault({
-      seedPhrase,
-      password: PASSWORD,
-      salt: SALT,
-      hdPathString: "m/44'/60'/0'/0",
-    }, (err, keystore) => {
-      if (err) reject(err);
-      resolve(keystore);
-    });
-  });
+export function inputPassword() {
+  const password = window.prompt('Enter your password to decrypt your lightwallet.');
+  return Promise.resolve(password);
 }
 
-export function deriveKeyForUnlockedKeystore() {
-  return new Promise((resolve, reject) => {
-    lightwallet.keystore.deriveKeyFromPassword(PASSWORD, SALT, (err, passwordKey) => {
-      if (err != null) reject(err);
-      resolve(passwordKey);
+export function ensureKeystoreHasAddress(keystore, password) {
+  const keyFromPassword = promisify(keystore.keyFromPassword.bind(keystore));
+  return keyFromPassword(password)
+    .then(passwordKey => {
+      keystore.generateNewAddress(passwordKey, 1);
+      return keystore;
     });
-  });
 }
 
+export function createEncryptedKeystore(seedPhrase, password) {
+  const createVault = promisify(lightwallet.keystore.createVault.bind(lightwallet.keystore));
+  return createVault({
+    seedPhrase,
+    password,
+    hdPathString: "m/44'/60'/0'/0",
+  })
+    .then(keystore => ensureKeystoreHasAddress(keystore, password))
+    .then(keystore => {
+      keystore.passwordProvider = (cb) => inputPassword().then(cb);
+      return keystore;
+    });
+}
+
+/**
+ * Create and activate a ProviderEngine that signs transactions with the keystore.
+ * @param {[type]} keystore [description]
+ */
 export function setWalletProvider(keystore) {
-  return new Promise((resolve) => {
-    keystore.keyFromPassword(PASSWORD, function (err, pwDerivedKey) {
-      keystore.generateNewAddress(pwDerivedKey, 1);
-      keystore.passwordProvider = passwordProvider;
+  const provider = new ProviderEngine();
+  provider.addProvider(new HookedWalletSubprovider({
+    getAccounts(callback) {
+      callback(null, keystore.getAddresses());
+    },
+    signTransaction: keystore.signTransaction.bind(keystore),
+  }));
+  const web3Provider = new Web3.providers.HttpProvider('https://ropsten.infura.io/');
+  provider.addProvider(new Web3Subprovider(web3Provider));
 
-      // Create a provider engine that uses the keystore to sign transactions.
-      const provider = new ProviderEngine();
-      provider.addProvider(new HookedWalletSubprovider({
-        getAccounts(callback) {
-          callback(null, keystore.getAddresses());
-        },
-        signTransaction: keystore.signTransaction.bind(keystore),
-      }));
-      const web3Provider = new Web3.providers.HttpProvider('https://ropsten.infura.io/');
-      provider.addProvider(new Web3Subprovider(web3Provider));
+  // Activate the provider, but stop polling for blocks since we don't use
+  // filter RPC calls.
+  provider.start();
+  provider.stop();
 
-      // Activate the provider, but stop polling for blocks since we don't use
-      // filter RPC calls.
-      provider.start();
-      provider.stop();
-
-      web3.setProvider(provider);
-      resolve(provider);
-    });
-  });
+  web3.setProvider(provider);
 }
+
+// The seed for the contribution flow is stored here. It's only the canonical
+// source for the seed when there's no provider yet.
+// FIXME: Global mutable state is painful to reason about. Use React
+// components instead.
+export let seed = null;
 
 // Manage a global reference to the current keystore so the seed can be fetched
 // when needed. It's easy for this keystore to accidentally get out of sync
@@ -78,12 +74,28 @@ export let keystore = null;
 
 export function setKeystore(newKeystore) {
   keystore = newKeystore;
+  seed = null;
 }
 
+export function setSeed(newSeed) {
+  seed = newSeed;
+  keystore = null;
+}
+
+/**
+ * Get the current seed both during the lightwallet creation process and afterwards.
+ */
 export function getSeed() {
-  if (keystore == null) {
-    return Promise.reject(new Error("The keystore hasn't been set, so you can't get the seed."));
+  if (keystore == null && seed == null) {
+    return Promise.reject(new Error('Neither the keystore nor the plaintext seed have been set yet.'));
   }
 
-  return deriveKeyForUnlockedKeystore().then(pwKey => keystore.getSeed(pwKey));
+  if (keystore != null) {
+    const keyFromPassword = promisify(keystore.keyFromPassword.bind(keystore));
+    return inputPassword()
+      .then(keyFromPassword)
+      .then(pwKey => keystore.getSeed(pwKey));
+  }
+
+  return Promise.resolve(seed);
 }

--- a/src/keystore.js
+++ b/src/keystore.js
@@ -9,6 +9,8 @@ import { web3 } from './web3';
 
 
 export function inputPassword() {
+  // FIXME: window.prompt has a cleartext input box. We need to build our own
+  // prompt with a real password input.
   const password = window.prompt('Enter your password to decrypt your lightwallet.');
   return Promise.resolve(password);
 }

--- a/src/router.js
+++ b/src/router.js
@@ -147,6 +147,11 @@ function setupRouter(options) {
               openSubView('view-campaign-contribute-wallet-confirm');
             });
           }],
+          ['/seed', function(params) {
+            openCampaignContribute(options, params, function(err, result){
+              openSubView('view-campaign-contribute-wallet-seed');
+            });
+          }],
           ['/password', function(params) {
             openCampaignContribute(options, params, function(err, result){
               openSubView('view-campaign-contribute-wallet-password');

--- a/src/views.js
+++ b/src/views.js
@@ -32,6 +32,7 @@ const subViews = [
   'view-campaign-contribute-wallet-entropy',
   'view-campaign-contribute-wallet-confirm',
   'view-campaign-contribute-wallet-balance',
+  'view-campaign-contribute-wallet-seed',
   'view-campaign-contribute-wallet-password',
 
   'view-campaign-contribute-wallet',


### PR DESCRIPTION
Add a step to the lightwallet flow for entering an encryption password. Manage the state of the seed alongside the keystore so we can delay the creation of a keystore and provider from when the seed is generated or entered to after the encryption password has been provided and confirmed.